### PR TITLE
proposal: event and logging architecture separation

### DIFF
--- a/docs/event_logging_architecture_proposal.md
+++ b/docs/event_logging_architecture_proposal.md
@@ -550,3 +550,517 @@ Create benchmark tests to measure:
 The proposed architecture provides a flexible, performant solution for separating logging and event handling from the main game loop. The Event Bus pattern with configurable processing modes offers the best balance between performance gains and implementation complexity.
 
 By implementing this architecture, the Vanilla game engine will gain significant performance improvements for I/O-intensive operations while maintaining responsive gameplay for time-critical events.
+
+## 10. Alternative Implementation: Ruby Fibers
+
+Ruby Fibers provide another approach to concurrency that can be better suited for games. This section explores how to implement the event system and logging using Fibers instead of threads.
+
+### 10.1 Fiber-Based Architecture
+
+```mermaid
+classDiagram
+    class FiberEventBus {
+        -Map~EventType, List~Subscriber~~ subscribers
+        -Map~Subscriber, ProcessingMode~ processingModes
+        -Map~Subscriber, Queue~ fiberQueues
+        -Map~Subscriber, Fiber~ fibers
+        -FiberScheduler scheduler
+        +subscribe(eventType, subscriber)
+        +unsubscribe(eventType, subscriber)
+        +publish(event)
+        +setProcessingMode(subscriber, mode)
+        +tick()
+    }
+
+    class FiberScheduler {
+        -List~Fiber~ activeFibers
+        -Int yieldInterval
+        +register(fiber)
+        +resume_all()
+        +run_nonblocking()
+    }
+
+    class Event {
+        +EventType type
+        +Map~String, Object~ data
+        +timestamp
+    }
+
+    class FiberLogger {
+        -LogLevel level
+        -Queue logQueue
+        -Fiber logFiber
+        -File logFile
+        +debug(message)
+        +info(message)
+        +warn(message)
+        +error(message)
+        +fatal(message)
+        -process_logs()
+    }
+
+    class GameLoop {
+        -FiberEventBus eventBus
+        -FiberScheduler scheduler
+        -List~System~ systems
+        +initialize()
+        +update(deltaTime)
+        +render()
+        +tick_fibers()
+    }
+
+    class ProcessingMode {
+        <<enumeration>>
+        IMMEDIATE
+        DEFERRED
+        SCHEDULED
+    }
+
+    FiberEventBus --o Event : publishes
+    FiberEventBus --o FiberScheduler : uses
+    GameLoop --o FiberEventBus : uses
+    FiberLogger --|> FiberEventBus : subscribes to
+    FiberEventBus --o ProcessingMode : configures
+```
+
+### 10.2 Fiber-Based Event Flow
+
+```mermaid
+sequenceDiagram
+    participant GL as GameLoop
+    participant EB as FiberEventBus
+    participant FS as FiberScheduler
+    participant CS as CriticalSubscriber
+    participant LG as FiberLogger
+
+    GL->>EB: publish(GameEvent)
+
+    alt Critical Event (Immediate)
+        EB->>CS: handleEvent(event)
+        CS-->>EB: return
+    else Non-Critical Event (Deferred)
+        EB->>EB: queue event for deferred handling
+    end
+
+    GL->>GL: continue game update
+    GL->>GL: finish rendering
+
+    GL->>FS: tick()
+    FS->>FS: resume all registered fibers
+
+    FS->>LG: resume log fiber
+    Note over LG: Process queued logs
+    LG-->>FS: yield control
+
+    FS-->>GL: return control
+    GL->>GL: begin next frame
+```
+
+### 10.3 Core FiberEventBus Implementation
+
+```ruby
+require 'fiber'
+
+module Vanilla
+  class FiberEventBus
+    include Singleton
+
+    PROCESSING_MODES = [:immediate, :deferred, :scheduled]
+
+    def initialize
+      @subscribers = Hash.new { |h, k| h[k] = [] }
+      @processing_modes = {}
+      @event_queues = {}
+      @fibers = {}
+      @running = true
+
+      # Setup scheduler for Ruby 3.0+
+      @scheduler = FiberScheduler.new
+    end
+
+    def subscribe(event_type, subscriber)
+      @subscribers[event_type] << subscriber
+      # Default to immediate mode unless specified
+      @processing_modes[subscriber] ||= :immediate
+
+      # Setup queue and fiber for deferred and scheduled subscribers
+      if @processing_modes[subscriber] != :immediate
+        setup_fiber_processing(subscriber)
+      end
+    end
+
+    def publish(event)
+      @subscribers[event.type].each do |subscriber|
+        case @processing_modes[subscriber]
+        when :immediate
+          subscriber.handle_event(event)
+        when :deferred, :scheduled
+          @event_queues[subscriber] << event
+        end
+      end
+    end
+
+    # Call this at the end of each game loop update
+    def tick
+      @scheduler.resume_all
+    end
+
+    def shutdown
+      @running = false
+      # Allow fibers to complete their work
+      tick
+    end
+
+    def set_processing_mode(subscriber, mode)
+      raise ArgumentError, "Invalid mode: #{mode}" unless PROCESSING_MODES.include?(mode)
+
+      old_mode = @processing_modes[subscriber]
+      @processing_modes[subscriber] = mode
+
+      if (mode == :deferred || mode == :scheduled) && old_mode == :immediate
+        setup_fiber_processing(subscriber)
+      end
+    end
+
+    private
+
+    def setup_fiber_processing(subscriber)
+      @event_queues[subscriber] ||= Queue.new
+
+      @fibers[subscriber] = Fiber.new do
+        while @running
+          # Process available events
+          while !@event_queues[subscriber].empty?
+            begin
+              event = @event_queues[subscriber].pop(true)
+              subscriber.handle_event(event)
+
+              # For deferred mode, yield after each event
+              # For scheduled mode, only yield at end of batch
+              Fiber.yield if @processing_modes[subscriber] == :deferred
+            rescue ThreadError
+              # Queue is empty
+              break
+            end
+          end
+
+          # Yield control back to scheduler
+          Fiber.yield
+        end
+      end
+
+      # Register with scheduler
+      @scheduler.register(@fibers[subscriber])
+    end
+  end
+
+  class FiberScheduler
+    def initialize
+      @fibers = []
+    end
+
+    def register(fiber)
+      @fibers << fiber
+    end
+
+    def resume_all
+      @fibers.each do |fiber|
+        fiber.resume if fiber.alive?
+      end
+    end
+  end
+end
+```
+
+### 10.4 Fiber-Based Logger Implementation
+
+```ruby
+module Vanilla
+  class FiberLogger
+    include Singleton
+
+    LOG_LEVELS = {
+      debug: 0,
+      info: 1,
+      warn: 2,
+      error: 3,
+      fatal: 4
+    }.freeze
+
+    def initialize
+      @level = ENV['VANILLA_LOG_LEVEL']&.downcase&.to_sym || :info
+      @log_env = ENV['VANILLA_LOG_DIR'] || 'development'
+      @log_dir = File.join(Dir.pwd, 'logs', @log_env)
+
+      FileUtils.mkdir_p(@log_dir) unless Dir.exist?(@log_dir)
+      @log_file = File.join(@log_dir, "vanilla_#{Time.now.strftime('%Y%m%d_%H%M%S')}.log")
+      @file = File.open(@log_file, 'w')
+
+      # Write header
+      @file.puts "=== Vanilla Game Log Started at #{Time.now} ==="
+      @file.flush
+
+      # Message queue
+      @message_queue = Queue.new
+
+      # Create fiber for processing logs
+      @logging_fiber = Fiber.new do
+        loop do
+          # Process all queued logs
+          process_logs
+
+          # Yield back to game loop
+          Fiber.yield
+        end
+      end
+
+      # Register with event bus
+      event_bus = FiberEventBus.instance
+      event_bus.subscribe(:log, self)
+      event_bus.set_processing_mode(self, :scheduled)
+
+      # Register fiber with scheduler
+      FiberEventBus.instance.scheduler.register(@logging_fiber)
+    end
+
+    def debug(message)
+      log_message(:debug, message)
+    end
+
+    def info(message)
+      log_message(:info, message)
+    end
+
+    def warn(message)
+      log_message(:warn, message)
+    end
+
+    def error(message)
+      log_message(:error, message)
+    end
+
+    def fatal(message)
+      log_message(:fatal, message)
+    end
+
+    def handle_event(event)
+      return unless event.type == :log
+
+      level = event.data[:level]
+      message = event.data[:message]
+      timestamp = event.data[:timestamp] || Time.now
+
+      @message_queue << [level, message, timestamp]
+    end
+
+    def close
+      # Process any remaining logs
+      process_logs
+
+      @file.puts "=== Vanilla Game Log Ended at #{Time.now} ==="
+      @file.close
+      @file = nil
+    end
+
+    private
+
+    def log_message(level, message)
+      return if LOG_LEVELS[level] < LOG_LEVELS[@level]
+
+      event = Event.new(
+        type: :log,
+        data: {
+          level: level,
+          message: message,
+          timestamp: Time.now
+        }
+      )
+
+      FiberEventBus.instance.publish(event)
+    end
+
+    def process_logs
+      while !@message_queue.empty?
+        begin
+          level, message, timestamp = @message_queue.pop(true)
+          write_log(level, message, timestamp)
+        rescue ThreadError
+          break
+        end
+      end
+    end
+
+    def write_log(level, message, timestamp)
+      formatted_time = timestamp.strftime('%Y-%m-%d %H:%M:%S.%L')
+      formatted_message = "[#{formatted_time}] [#{level.to_s.upcase}] #{message}"
+      @file.puts(formatted_message)
+      @file.flush
+    end
+  end
+end
+```
+
+### 10.5 Game Loop Integration with Fibers
+
+```ruby
+module Vanilla
+  class Game
+    def initialize
+      # Initialize systems
+      @event_bus = FiberEventBus.instance
+      @logger = FiberLogger.instance
+
+      # Other game initialization
+      # ...
+    end
+
+    def update(delta_time)
+      # Update game state
+      # ...
+
+      # Process immediate events directly
+      # Deferred and scheduled events will be processed when tick_fibers is called
+    end
+
+    def render
+      # Render game state
+      # ...
+    end
+
+    def run
+      last_time = Time.now
+
+      loop do
+        current_time = Time.now
+        delta_time = current_time - last_time
+        last_time = current_time
+
+        update(delta_time)
+        render
+
+        # Tick fibers at the end of the frame
+        # This gives fibers a chance to run without blocking the game loop
+        tick_fibers
+
+        # Cap frame rate if needed
+        # ...
+      end
+    end
+
+    private
+
+    def tick_fibers
+      @event_bus.tick
+    end
+  end
+end
+```
+
+### 10.6 Benefits of Fiber-Based Approach
+
+1. **Resource Efficiency**:
+   - Fibers are lightweight (approximately 4KB per fiber vs ~1MB per thread)
+   - No OS-level context switching overhead
+   - Lower memory footprint for large numbers of concurrent tasks
+
+2. **Cooperative Multitasking**:
+   - Explicit yield points give precise control over when fibers run
+   - No preemption means fewer race conditions
+   - Simpler synchronization (often no mutexes needed)
+
+3. **Deterministic Behavior**:
+   - Game loop maintains control over when fibers run
+   - Easier to debug since execution order is more predictable
+   - Better for game development where determinism is important
+
+4. **Improved in Ruby 3.0+**:
+   - Fiber scheduler API (`Fiber.scheduler`) for auto-scheduling
+   - Non-blocking I/O integration with Fibers
+   - Better support for asynchronous programming
+
+### 10.7 Drawbacks of Fiber-Based Approach
+
+1. **Limited Parallelism**:
+   - Fibers in Ruby are not parallel (only one runs at a time)
+   - Cannot utilize multiple CPU cores directly
+   - CPU-bound tasks will block other fibers
+
+2. **Explicit Yield Requirement**:
+   - Fibers must explicitly yield control
+   - Long-running operations need to be broken into smaller steps
+   - Third-party libraries may not be fiber-aware
+
+3. **Development Complexity**:
+   - Less familiar to many developers than thread-based concurrency
+   - Requires careful consideration of where to yield
+   - Error handling is more complex in fiber-based code
+
+4. **Ruby Version Requirements**:
+   - Best features require Ruby 3.0+ for scheduler support
+   - Older Ruby versions have less efficient fiber implementations
+   - Non-blocking I/O integration is limited in older Ruby versions
+
+### 10.8 Background Jobs Alternative
+
+For operations that need true parallelism or should run outside the game process:
+
+```ruby
+# Using a simple background job system (Sidekiq-like)
+module Vanilla
+  class BackgroundJob
+    def self.enqueue(job_class, *args)
+      Thread.new do
+        job = job_class.new
+        job.perform(*args)
+      end
+    end
+  end
+
+  class AnalyticsJob
+    def perform(event_data)
+      # Connect to external service
+      # Send analytics data
+      # This runs in a separate thread
+    end
+  end
+
+  # Usage:
+  BackgroundJob.enqueue(AnalyticsJob, { level: 5, score: 10000 })
+```
+
+### 10.9 Recommended Hybrid Approach
+
+We recommend a hybrid approach that combines the best aspects of threads, fibers, and background jobs:
+
+1. **Use Fibers for:**
+   - In-game event handling (logging, achievements, etc.)
+   - Processing game state updates that can be deferred
+   - Any I/O that can be made non-blocking
+
+2. **Use Threads for:**
+   - I/O operations that cannot be made non-blocking
+   - CPU-intensive tasks that would block the game loop
+   - Tasks that need true parallelism
+
+3. **Use Background Jobs for:**
+   - Analytics and telemetry
+   - Cloud saves and synchronization
+   - Content downloads and updates
+   - Any task that can be completely separated from the game
+
+### 10.10 Implementation Recommendation
+
+For the Vanilla game engine, we recommend:
+
+1. **Start with Fiber-based architecture** for the event system and logger
+2. **Use Ruby 3.0+ features** like `Fiber.scheduler` when available
+3. **Fall back to threads** for operations that need parallelism
+4. **Consider a simple background job system** for completely separate operations
+
+This hybrid approach provides the best balance of:
+- Performance (faster game loop, less resource usage)
+- Simplicity (easier to reason about than complex thread synchronization)
+- Scalability (can use multiple cores when needed)
+- Flexibility (different processing approaches for different needs)
+
+By implementing this architecture, Vanilla will achieve the goal of separating logging and event handling from the main game loop while gaining additional performance and maintainability benefits.


### PR DESCRIPTION
https://blog.saeloun.com/2022/03/01/ruby-fibers-101/

```ruby 
#!/usr/bin/env ruby
# Benchmark comparing memory usage of Ruby Fibers vs Threads
# Run with: ruby fibers_vs_threads_benchmark.rb

require 'benchmark'

# Function to get memory usage in MB
def memory_usage
  # Using `ps` command to get memory usage since Process.rss isn't available on all platforms
  if RUBY_PLATFORM =~ /darwin/
    # macOS
    `ps -o rss= -p #{Process.pid}`.to_i / 1024.0
  elsif RUBY_PLATFORM =~ /linux/
    # Linux
    `ps -o rss= -p #{Process.pid}`.to_i / 1024.0
  else
    # Windows or other - fallback to rough estimate
    GC.stat[:malloc_increase_bytes] / 1024.0 / 1024.0
  end
end

# Function to report memory stats
def report_memory(label, count, before, after)
  puts "#{label}:"
  puts "  Created #{count} objects"
  puts "  Memory before: #{before} MB"
  puts "  Memory after:  #{after} MB"
  puts "  Memory usage:  #{(after - before).round(2)} MB"
  puts "  Per object:    #{((after - before) * 1024 * 1024 / count).round(2)} bytes"
  puts
end

# Tests multiple counts to see how scaling affects memory usage
[100, 1000, 2000].each do |count|
  puts "=== Testing with #{count} objects ==="
  puts

  # Empty array for reference measurement
  GC.start
  empty_before = memory_usage
  array = []
  count.times { array << Object.new }
  empty_after = memory_usage
  report_memory("Empty objects (control)", count, empty_before, empty_after)
  array = nil

  # Thread benchmark
  GC.start
  thread_before = memory_usage
  threads = []
  count.times do
    threads << Thread.new { sleep }
  end
  thread_after = memory_usage
  report_memory("Threads", count, thread_before, thread_after)
  threads.each(&:kill)
  threads = nil

  # Fiber benchmark
  GC.start
  fiber_before = memory_usage
  fibers = []
  count.times do
    fibers << Fiber.new { print "h" ; Fiber.yield("hx") }
  end
  fiber_after = memory_usage
  report_memory("Fibers", count, fiber_before, fiber_after)
  fibers = nil

  puts "=== Memory usage comparison ==="
  diff_thread = thread_after - thread_before
  diff_fiber = fiber_after - fiber_before

  if diff_fiber > 0
    puts "Threads vs Fibers ratio: #{(diff_thread / diff_fiber).round(2)}x"
  else
    puts "Fiber memory usage too small to calculate accurate ratio"
  end

  puts
  puts "-------------------------------------------------------"
  puts
end

# Analyze thread vs fiber creation time
puts "=== Creation time benchmark ==="
count = 1000

Benchmark.bm(10) do |x|
  x.report("Threads:") do
    threads = []
    count.times do
      threads << Thread.new { sleep 0.0001 }
    end
    threads.each(&:join)
  end

  x.report("Fibers:") do
    fibers = []
    count.times do
      fibers << Fiber.new { Fiber.yield }
    end
    fibers.each(&:resume)
  end
end

puts
puts "=== NOTES ==="
puts "1. The exact memory usage depends on Ruby version and implementation (MRI, JRuby, etc.)"
puts "2. Thread size varies by platform and may be affected by stack size settings"
puts "3. Memory usage includes Ruby's internal overhead"
puts "4. Fibers are cooperative and only one runs at a time, while threads can run in parallel"
puts "5. Ruby VM version: #{RUBY_DESCRIPTION}"

```

--------------

```ruby
# fiber.rb

def async_task(task_id)
  Fiber.new do
    puts "Task #{task_id} started"
    sleep(0.5) # Simulate I/O operation
    Fiber.yield("Task #{task_id} completed")
  end
end

tasks = [async_task(1), async_task(2), async_task(3)]

while tasks.any?
  tasks.each do |task|
    if task.alive?
      result = task.resume
      puts result if result
    end
  end
  tasks.reject!{|task| !task.alive?}
end
```






```
=== Testing with 100 objects ===

Empty objects (control):
  Created 100 objects
  Memory before: 12.359375 MB
  Memory after:  12.453125 MB
  Memory usage:  0.09 MB
  Per object:    983.04 bytes

Threads:
  Created 100 objects
  Memory before: 12.46875 MB
  Memory after:  17.28125 MB
  Memory usage:  4.81 MB
  Per object:    50462.72 bytes

Fibers:
  Created 100 objects
  Memory before: 15.71875 MB
  Memory after:  15.75 MB
  Memory usage:  0.03 MB
  Per object:    327.68 bytes

=== Memory usage comparison ===
Threads vs Fibers ratio: 154.0x

-------------------------------------------------------

=== Testing with 1000 objects ===

Empty objects (control):
  Created 1000 objects
  Memory before: 17.265625 MB
  Memory after:  17.265625 MB
  Memory usage:  0.0 MB
  Per object:    0.0 bytes

Threads:
  Created 1000 objects
  Memory before: 17.265625 MB
  Memory after:  65.265625 MB
  Memory usage:  48.0 MB
  Per object:    50331.65 bytes

Fibers:
  Created 1000 objects
  Memory before: 63.703125 MB
  Memory after:  50.6875 MB
  Memory usage:  -13.02 MB
  Per object:    -13647.87 bytes

=== Memory usage comparison ===
Fiber memory usage too small to calculate accurate ratio

-------------------------------------------------------

=== Testing with 2000 objects ===

Empty objects (control):
  Created 2000 objects
  Memory before: 48.375 MB
  Memory after:  48.375 MB
  Memory usage:  0.0 MB
  Per object:    0.0 bytes

Threads:
  Created 2000 objects
  Memory before: 48.3125 MB
  Memory after:  136.3125 MB
  Memory usage:  88.0 MB
  Per object:    46137.34 bytes

Fibers:
  Created 2000 objects
  Memory before: 135.140625 MB
  Memory after:  106.90625 MB
  Memory usage:  -28.23 MB
  Per object:    -14802.94 bytes

=== Memory usage comparison ===
Fiber memory usage too small to calculate accurate ratio

-------------------------------------------------------

=== Creation time benchmark ===
                 user     system      total        real
Threads:     0.018389   0.081694   0.100083 (  0.063960)
Fibers:      0.001446   0.003843   0.005289 (  0.005254)
```