### PR TITLE
Add faction system foundation (Proposal 010)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ The codebase is built around three core pillars:
    - `InputComponent`: Player input state
    - `InventoryComponent`: Item storage
    - `CombatComponent`: Combat stats
+   - `FactionComponent`: Faction membership and hostility (data only; hostility logic lives in `Vanilla::Factions`)
 
 3. **Systems** (`lib/vanilla/systems/`): Logic that operates on entities with specific component combinations. Systems run in priority order:
    - **MazeSystem (0)**: Generates procedural mazes

--- a/documents/proposals/010_faction_system_proposal.md
+++ b/documents/proposals/010_faction_system_proposal.md
@@ -1,0 +1,191 @@
+# Faction System (Foundation) - Proposal 010
+
+## Status
+
+**Phase 1 (this proposal): implemented.** Foundation only — a data model and
+hostility queries, wired into the existing player-vs-monster combat with no
+change to observable gameplay. Phase 2 (monster targeting/AI that *uses*
+factions) is described under [Future Work](#future-work) and is intentionally
+out of scope here.
+
+## Overview
+
+Today the game tells entities apart with a direct `@player` reference (held by
+`MonsterSystem`) and entity **tags** (`:player`, `:monster`). Combat routing is
+hard-coded around those tags: `AttackCommand` starts turn-based combat only when
+"a `:player` attacks a `:monster`".
+
+This proposal introduces a **faction** as the first-class notion of *"who is an
+enemy of whom"*. An entity belongs to a faction and declares which factions it
+treats as hostile. Combat then asks *"are these two hostile?"* instead of
+*"is one the player and the other a monster?"*.
+
+This makes the architecture **player-agnostic** and unlocks (in later phases)
+allied NPCs, monster-vs-monster infighting, and dynamic diplomacy — without the
+combat code needing to know about "the player" specifically.
+
+The design follows the analysis written up for the r/roguelikedev thread
+(see `reddit_response_enemy_targeting copy.md`, linked from GitHub issue #119),
+adapted to respect this codebase's ECS discipline.
+
+## Motivation
+
+Current coupling and its limits:
+
+- `AttackCommand` (`lib/vanilla/commands/attack_command.rb`) branches on
+  `has_tag?(:player) && has_tag?(:monster)`.
+- `MonsterSystem` (`lib/vanilla/systems/monster_system.rb`) takes a direct
+  `player:` reference for spawn placement and collision checks.
+
+Consequences:
+
+- **No allied NPCs** — anything that isn't the player is implicitly an enemy.
+- **No monster infighting** — two monster types can't be hostile to each other.
+- **Player-centric systems** — combat/AI logic can't reason about a third party.
+
+A faction component decouples "what kind of thing is this" (tags) from "who does
+it fight" (faction), which is the axis combat actually cares about.
+
+## Design
+
+### New Component: `FactionComponent`
+
+A **pure data** container (`lib/vanilla/components/faction_component.rb`):
+
+```ruby
+FactionComponent.new(faction_id: :hero, hostile_to: [:monster])
+```
+
+| Field        | Type           | Meaning                                   |
+|--------------|----------------|-------------------------------------------|
+| `faction_id` | `Symbol`       | the faction this entity belongs to        |
+| `hostile_to` | `Set<Symbol>`  | faction ids this entity treats as enemies |
+
+It implements the component contract (`type`, `to_hash`, `from_hash`) and is
+registered with `Component.register`.
+
+#### Why the logic lives *outside* the component
+
+The project enforces a custom RuboCop cop, `ECS/ComponentBehavior`, which allows
+components to define **only** `initialize`, `type`, `to_hash`, `from_hash`, and
+attribute writers. Predicate methods such as `hostile_to?`/`ally_of?` (as drafted
+in the original Reddit write-up) would violate it. So the **behaviour** lives in
+a separate module, keeping the component a pure data bag — which is also the
+better ECS design.
+
+#### Why `faction_id` defaults to `:neutral`
+
+`Component.register` instantiates each class with no arguments
+(`klass.new rescue return`). A component whose `initialize` has a *required*
+keyword therefore fails to register silently (this already affects several
+existing components — see [Known Limitations](#known-limitations)). Defaulting
+`faction_id: :neutral` makes `FactionComponent` register cleanly **and** gives a
+sensible meaning to "an entity with no declared faction": neutral, hostile to
+nobody. This was verified with a full `Entity#to_hash` → `Entity.from_hash`
+round-trip preserving the faction.
+
+### New Module: `Vanilla::Factions`
+
+Canonical faction ids and the hostility/ally queries
+(`lib/vanilla/factions.rb`):
+
+```ruby
+Vanilla::Factions::HERO      # => :hero
+Vanilla::Factions::MONSTER   # => :monster
+Vanilla::Factions::NEUTRAL   # => :neutral
+
+Vanilla::Factions.hostile?(attacker, target) # => Boolean
+Vanilla::Factions.allies?(entity, other)     # => Boolean
+```
+
+Both queries are **nil-safe** and treat an entity with no `FactionComponent` as
+neutral (hostile to nobody, allied with nobody), so partially-migrated content
+never raises.
+
+### Entity wiring (`EntityFactory`)
+
+| Entity   | `faction_id` | `hostile_to` |
+|----------|--------------|--------------|
+| Player   | `:hero`      | `[:monster]` |
+| Monster  | `:monster`   | `[:hero]`    |
+
+### Combat routing (`AttackCommand`)
+
+Before:
+
+```ruby
+if @attacker.has_tag?(:player) && @target.has_tag?(:monster)
+  combat_system.process_turn_based_combat(@attacker, @target)
+else
+  combat_system.process_attack(@attacker, @target)
+end
+```
+
+After:
+
+```ruby
+if player_initiated_against_hostile?   # has_tag?(:player) && Factions.hostile?(attacker, target)
+  combat_system.process_turn_based_combat(@attacker, @target)
+else
+  combat_system.process_attack(@attacker, @target)
+end
+```
+
+The `:player` tag is deliberately retained for the turn-based branch: turn-based
+combat is the player's *interactive* UX, which is about **control**, not
+**hostility**. Only the "is the target an enemy?" question is delegated to
+factions.
+
+## Scope boundaries (what this proposal does **not** touch)
+
+- **`CollisionSystem`** handles player–stairs and player–item interactions.
+  Those are not hostility relationships (stairs and items are not combatants), so
+  they remain tag-based and are intentionally left unchanged.
+- **`CombatSystem`** uses `has_tag?(:player)` for death handling / kill credit —
+  that is about player *identity*, not faction, and is left unchanged.
+- **`MonsterSystem`** keeps its direct `player:` reference. Removing that belongs
+  to Phase 2, where monsters gain real targeting.
+
+## Behaviour preservation
+
+This change is a **refactor with no observable gameplay difference**:
+
+- The only entities that exist today are the player (`:hero`) and monsters
+  (`:monster`), and they are mutually hostile.
+- `hostile?(player, monster)` is therefore `true` exactly when the old
+  `has_tag?(:monster)` check was true, so combat routes identically.
+- Entities without a faction are treated as non-hostile, matching the old
+  "non-player attacker uses a single attack" fallback.
+
+## Testing
+
+- `spec/lib/vanilla/components/faction_component_spec.rb` — initialization,
+  defaults, `type`, registry registration, and `to_hash`/`from_hash` round-trip.
+- `spec/lib/vanilla/factions_spec.rb` — `hostile?`/`allies?` including reciprocity,
+  same-faction, neutral, missing-component, and nil cases.
+- `spec/lib/vanilla/commands/attack_command_spec.rb` — new cases proving the
+  player-vs-hostile path starts turn-based combat while non-hostile and
+  non-player attacks fall back to a single attack.
+
+## Known limitations
+
+- **Registry gap (pre-existing):** `Component.register` swallows the
+  `ArgumentError` from required-keyword initializers, so several components with
+  required kwargs are not actually registered. `FactionComponent` sidesteps this
+  with a default. A broader fix to `register` is out of scope for this proposal.
+
+## Future Work (Phase 2)
+
+The payoff of factions arrives when something *queries* them for targeting. None
+of this is implemented yet:
+
+1. **Monster targeting/AI** — replace `MonsterSystem`'s direct `player:`
+   reference with `Factions.hostile?`-based target selection
+   (`find_nearest_hostile`), so monsters pursue any enemy, not just "the player".
+2. **Allied NPCs / companions** — entities sharing the `:hero` faction.
+3. **Additional factions** — e.g. `:undead` hostile to everyone, enabling
+   three-way fights for free.
+4. **Dynamic relationships** — mutate `hostile_to` at runtime for diplomacy,
+   betrayal, or "faction disguise" effects.
+5. **Performance** — if hostile-entity queries become hot, add spatial
+   partitioning or a per-faction hostility cache invalidated on spawn/death.

--- a/lib/vanilla.rb
+++ b/lib/vanilla.rb
@@ -42,6 +42,9 @@ module Vanilla
   # entities
   require_relative 'vanilla/entities'
 
+  # faction hostility/ally queries (operate on FactionComponent data)
+  require_relative 'vanilla/factions'
+
   # event system
   require_relative 'vanilla/events'
 

--- a/lib/vanilla/commands/attack_command.rb
+++ b/lib/vanilla/commands/attack_command.rb
@@ -32,18 +32,28 @@ module Vanilla
 
         @logger.info("[AttackCommand] Executing attack: #{@attacker.id} attacks #{@target.id}")
 
-        # If player is attacking, start turn-based combat
-        if @attacker.has_tag?(:player) && @target.has_tag?(:monster)
+        # The player drives the interactive, turn-based combat loop when it
+        # attacks a hostile entity. Hostility is decided by faction rather than
+        # by a hard-coded :monster tag, so any future hostile faction (undead,
+        # rival NPCs, ...) routes through the same path automatically.
+        if player_initiated_against_hostile?
           @logger.info("[AttackCommand] Starting turn-based combat")
           combat_system.process_turn_based_combat(@attacker, @target)
         else
-          # Single attack for non-player attacks
+          # Single attack for everything else (e.g. a monster striking back).
           combat_system.process_attack(@attacker, @target)
         end
 
         @executed = true
       end
+
+      private
+
+      # @return [Boolean] true when the player is the attacker and the target
+      #   is hostile to it (the case that warrants interactive, turn-based combat)
+      def player_initiated_against_hostile?
+        @attacker.has_tag?(:player) && Vanilla::Factions.hostile?(@attacker, @target)
+      end
     end
   end
 end
-

--- a/lib/vanilla/components.rb
+++ b/lib/vanilla/components.rb
@@ -28,5 +28,6 @@ module Vanilla
     require_relative 'components/combat_component'
     require_relative 'components/visibility_component'
     require_relative 'components/dev_mode_component'
+    require_relative 'components/faction_component'
   end
 end

--- a/lib/vanilla/components/faction_component.rb
+++ b/lib/vanilla/components/faction_component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Vanilla
+  module Components
+    # Identifies which faction an entity belongs to and which factions it
+    # treats as hostile.
+    #
+    # This is a *pure data* container by design: it stores a faction id and a
+    # set of hostile faction ids, and nothing else. The logic for deciding
+    # whether two entities are hostile or allied lives in {Vanilla::Factions}
+    # so that this class stays within the ECS/ComponentBehavior cop's rules
+    # (components may only define initialize, type, to_hash, from_hash and
+    # attribute accessors).
+    #
+    # @example Give an entity a faction
+    #   entity.add_component(
+    #     FactionComponent.new(faction_id: :hero, hostile_to: [:monster])
+    #   )
+    #
+    # @see Vanilla::Factions for hostility/ally queries.
+    class FactionComponent < Component
+      # @return [Symbol] the faction this entity belongs to
+      attr_accessor :faction_id
+
+      # @return [Set<Symbol>] faction ids this entity is hostile toward
+      attr_accessor :hostile_to
+
+      # @param faction_id [Symbol] the entity's own faction. Defaults to
+      #   +:neutral+ so the component can be registered (Component.register
+      #   instantiates with no arguments) and so an entity with an unspecified
+      #   faction is hostile to nobody.
+      # @param hostile_to [Array<Symbol>, Set<Symbol>] factions treated as enemies
+      def initialize(faction_id: :neutral, hostile_to: [])
+        super()
+        @faction_id = faction_id
+        @hostile_to = Set.new(hostile_to)
+      end
+
+      # @return [Symbol] the component type used by the ECS registry
+      def type
+        :faction
+      end
+
+      # @return [Hash] serialized representation (round-trips via {from_hash})
+      def to_hash
+        { type: type, faction_id: @faction_id, hostile_to: @hostile_to.to_a }
+      end
+
+      # Rebuild a component from its serialized hash.
+      # @param hash [Hash] data produced by {#to_hash}
+      # @return [FactionComponent]
+      def self.from_hash(hash)
+        new(faction_id: hash[:faction_id] || :neutral, hostile_to: hash[:hostile_to] || [])
+      end
+    end
+
+    Component.register(FactionComponent)
+  end
+end

--- a/lib/vanilla/entity_factory.rb
+++ b/lib/vanilla/entity_factory.rb
@@ -16,6 +16,7 @@ module Vanilla
       player.add_component(Vanilla::Components::InventoryComponent.new(max_size: 20))
       player.add_component(Vanilla::Components::CurrencyComponent.new(0, :gold))
       player.add_component(Vanilla::Components::VisibilityComponent.new(vision_radius: 3))
+      player.add_component(Vanilla::Components::FactionComponent.new(faction_id: Vanilla::Factions::HERO, hostile_to: [Vanilla::Factions::MONSTER]))
 
       # Add dev mode component if requested
       if dev_mode
@@ -45,6 +46,7 @@ module Vanilla
       monster.add_component(Vanilla::Components::RenderComponent.new(character: Vanilla::Support::TileType::MONSTER, color: :white))
       monster.add_component(Vanilla::Components::HealthComponent.new(max_health: health))
       monster.add_component(Vanilla::Components::CombatComponent.new(attack_power: damage, defense: 1, accuracy: 0.7))
+      monster.add_component(Vanilla::Components::FactionComponent.new(faction_id: Vanilla::Factions::MONSTER, hostile_to: [Vanilla::Factions::HERO]))
       monster
     end
   end

--- a/lib/vanilla/factions.rb
+++ b/lib/vanilla/factions.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Vanilla
+  # Canonical faction identifiers and the hostility/ally queries that operate
+  # on them.
+  #
+  # {Vanilla::Components::FactionComponent} is a pure data container, so the
+  # *behaviour* of factions — deciding whether two entities are enemies or
+  # allies — lives here. Systems and commands call these helpers instead of
+  # checking entity tags such as +:player+ / +:monster+ directly, which keeps
+  # combat targeting player-agnostic and ready for allied NPCs or
+  # monster-vs-monster combat (see
+  # documents/proposals/010_faction_system_proposal.md).
+  #
+  # Entities without a FactionComponent are treated as neutral: hostile to
+  # nobody and allied with nobody.
+  module Factions
+    # The player's faction.
+    HERO = :hero
+    # The default faction for spawned monsters.
+    MONSTER = :monster
+    # Entities with no declared allegiance.
+    NEUTRAL = :neutral
+
+    module_function
+
+    # Whether +attacker+ regards +target+ as an enemy.
+    #
+    # @param attacker [Vanilla::Entities::Entity, nil]
+    # @param target [Vanilla::Entities::Entity, nil]
+    # @return [Boolean] true only when both entities have a faction and the
+    #   attacker's faction lists the target's faction as hostile
+    def hostile?(attacker, target)
+      attacker_faction = faction_of(attacker)
+      target_faction = faction_of(target)
+      return false unless attacker_faction && target_faction
+
+      attacker_faction.hostile_to.include?(target_faction.faction_id)
+    end
+
+    # Whether two entities belong to the same faction.
+    #
+    # @param entity [Vanilla::Entities::Entity, nil]
+    # @param other [Vanilla::Entities::Entity, nil]
+    # @return [Boolean] true only when both entities share a faction id
+    def allies?(entity, other)
+      entity_faction = faction_of(entity)
+      other_faction = faction_of(other)
+      return false unless entity_faction && other_faction
+
+      entity_faction.faction_id == other_faction.faction_id
+    end
+
+    # @api private
+    # @return [Vanilla::Components::FactionComponent, nil]
+    def faction_of(entity)
+      entity&.get_component(:faction)
+    end
+  end
+end

--- a/spec/lib/vanilla/commands/attack_command_spec.rb
+++ b/spec/lib/vanilla/commands/attack_command_spec.rb
@@ -92,6 +92,45 @@ RSpec.describe Vanilla::Commands::AttackCommand do
         expect { command.execute(world) }.not_to raise_error
       end
     end
+
+    context 'when routing combat by faction' do
+      before do
+        allow(world).to receive(:systems).and_return([[combat_system, 3]])
+        allow(combat_system).to receive(:is_a?).with(Vanilla::Systems::CombatSystem).and_return(true)
+        allow(combat_system).to receive(:process_attack)
+        allow(combat_system).to receive(:process_turn_based_combat)
+      end
+
+      def faction(id, hostile_to)
+        Vanilla::Components::FactionComponent.new(faction_id: id, hostile_to: hostile_to)
+      end
+
+      it 'starts turn-based combat when the player attacks a hostile target' do
+        attacker.add_tag(:player)
+        attacker.add_component(faction(Vanilla::Factions::HERO, [Vanilla::Factions::MONSTER]))
+        target.add_component(faction(Vanilla::Factions::MONSTER, [Vanilla::Factions::HERO]))
+
+        expect(combat_system).to receive(:process_turn_based_combat).with(attacker, target)
+        described_class.new(attacker, target).execute(world)
+      end
+
+      it 'falls back to a single attack when the player target is not hostile' do
+        attacker.add_tag(:player)
+        attacker.add_component(faction(Vanilla::Factions::HERO, [Vanilla::Factions::MONSTER]))
+        target.add_component(faction(Vanilla::Factions::HERO, [Vanilla::Factions::MONSTER]))
+
+        expect(combat_system).to receive(:process_attack).with(attacker, target)
+        described_class.new(attacker, target).execute(world)
+      end
+
+      it 'uses a single attack when a non-player attacks (e.g. monster retaliation)' do
+        attacker.add_component(faction(Vanilla::Factions::MONSTER, [Vanilla::Factions::HERO]))
+        target.add_tag(:player)
+        target.add_component(faction(Vanilla::Factions::HERO, [Vanilla::Factions::MONSTER]))
+
+        expect(combat_system).to receive(:process_attack).with(attacker, target)
+        described_class.new(attacker, target).execute(world)
+      end
+    end
   end
 end
-

--- a/spec/lib/vanilla/components/faction_component_spec.rb
+++ b/spec/lib/vanilla/components/faction_component_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Vanilla::Components::FactionComponent do
+  describe '#initialize' do
+    it 'sets faction_id and hostile_to' do
+      component = described_class.new(faction_id: :hero, hostile_to: [:monster])
+      expect(component.faction_id).to eq(:hero)
+      expect(component.hostile_to).to eq(Set.new([:monster]))
+    end
+
+    it 'stores hostile_to as a Set (deduplicating entries)' do
+      component = described_class.new(faction_id: :hero, hostile_to: [:monster, :monster, :undead])
+      expect(component.hostile_to).to eq(Set.new([:monster, :undead]))
+    end
+
+    it 'defaults to a neutral faction hostile to nobody' do
+      component = described_class.new
+      expect(component.faction_id).to eq(:neutral)
+      expect(component.hostile_to).to be_empty
+    end
+  end
+
+  describe '#type' do
+    it 'returns :faction' do
+      expect(described_class.new.type).to eq(:faction)
+    end
+  end
+
+  describe 'registration' do
+    it 'is registered with the component registry' do
+      expect(Vanilla::Components::Component.get_class(:faction)).to eq(described_class)
+    end
+  end
+
+  describe '#to_hash' do
+    it 'serializes faction data with its type' do
+      component = described_class.new(faction_id: :hero, hostile_to: [:monster])
+      hash = component.to_hash
+      expect(hash[:type]).to eq(:faction)
+      expect(hash[:faction_id]).to eq(:hero)
+      expect(hash[:hostile_to]).to contain_exactly(:monster)
+    end
+  end
+
+  describe '.from_hash' do
+    it 'deserializes faction data' do
+      hash = { type: :faction, faction_id: :hero, hostile_to: [:monster, :undead] }
+      component = described_class.from_hash(hash)
+      expect(component).to be_a(described_class)
+      expect(component.faction_id).to eq(:hero)
+      expect(component.hostile_to).to eq(Set.new([:monster, :undead]))
+    end
+
+    it 'tolerates missing fields by falling back to neutral defaults' do
+      component = described_class.from_hash({ type: :faction })
+      expect(component.faction_id).to eq(:neutral)
+      expect(component.hostile_to).to be_empty
+    end
+  end
+
+  describe 'round-trip serialization' do
+    it 'preserves faction data through to_hash/from_hash' do
+      original = described_class.new(faction_id: :hero, hostile_to: [:monster, :undead])
+      restored = described_class.from_hash(original.to_hash)
+      expect(restored.faction_id).to eq(original.faction_id)
+      expect(restored.hostile_to).to eq(original.hostile_to)
+    end
+  end
+end

--- a/spec/lib/vanilla/factions_spec.rb
+++ b/spec/lib/vanilla/factions_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Vanilla::Factions do
+  # Build a bare entity optionally carrying a FactionComponent.
+  def entity_with_faction(faction_id: nil, hostile_to: [])
+    Vanilla::Entities::Entity.new.tap do |entity|
+      next if faction_id.nil?
+
+      entity.add_component(
+        Vanilla::Components::FactionComponent.new(faction_id: faction_id, hostile_to: hostile_to)
+      )
+    end
+  end
+
+  let(:hero)    { entity_with_faction(faction_id: described_class::HERO, hostile_to: [described_class::MONSTER]) }
+  let(:monster) { entity_with_faction(faction_id: described_class::MONSTER, hostile_to: [described_class::HERO]) }
+  let(:ally)    { entity_with_faction(faction_id: described_class::HERO, hostile_to: [described_class::MONSTER]) }
+  let(:neutral) { entity_with_faction(faction_id: described_class::NEUTRAL) }
+  let(:factionless) { entity_with_faction(faction_id: nil) }
+
+  describe '.hostile?' do
+    it 'is true when the attacker faction lists the target faction as hostile' do
+      expect(described_class.hostile?(hero, monster)).to be true
+    end
+
+    it 'is reciprocal when both factions list each other as hostile' do
+      expect(described_class.hostile?(monster, hero)).to be true
+    end
+
+    it 'is false between members of the same faction' do
+      expect(described_class.hostile?(hero, ally)).to be false
+    end
+
+    it 'is false toward a neutral faction nobody declared hostile' do
+      expect(described_class.hostile?(hero, neutral)).to be false
+    end
+
+    it 'is false when either entity lacks a faction component' do
+      expect(described_class.hostile?(hero, factionless)).to be false
+      expect(described_class.hostile?(factionless, hero)).to be false
+    end
+
+    it 'is false when either entity is nil' do
+      expect(described_class.hostile?(hero, nil)).to be false
+      expect(described_class.hostile?(nil, monster)).to be false
+    end
+  end
+
+  describe '.allies?' do
+    it 'is true for entities sharing a faction' do
+      expect(described_class.allies?(hero, ally)).to be true
+    end
+
+    it 'is false for entities in different factions' do
+      expect(described_class.allies?(hero, monster)).to be false
+    end
+
+    it 'is false when either entity lacks a faction component' do
+      expect(described_class.allies?(hero, factionless)).to be false
+    end
+
+    it 'is false when either entity is nil' do
+      expect(described_class.allies?(nil, hero)).to be false
+    end
+  end
+end

--- a/spec/lib/vanilla/systems/message_system_combat_menu_spec.rb
+++ b/spec/lib/vanilla/systems/message_system_combat_menu_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe Vanilla::Systems::MessageSystem do
   let(:world) { instance_double('Vanilla::World') }
   let(:system) { described_class.new(world) }
   let(:logger) { instance_double('Vanilla::Logger') }
-  let(:player) { Vanilla::Entities::Entity.new.tap { |e| e.name = "Player"; e.add_tag(:player) } }
-  let(:monster) { Vanilla::Entities::Entity.new.tap { |e| e.name = "Goblin"; e.add_tag(:monster) } }
+  let(:player) { Vanilla::Entities::Entity.new.tap { |e| e.name = "Player"; e.add_tag(:player); e.add_component(hero_faction) } }
+  let(:monster) { Vanilla::Entities::Entity.new.tap { |e| e.name = "Goblin"; e.add_tag(:monster); e.add_component(monster_faction) } }
+  let(:hero_faction) { Vanilla::Components::FactionComponent.new(faction_id: Vanilla::Factions::HERO, hostile_to: [Vanilla::Factions::MONSTER]) }
+  let(:monster_faction) { Vanilla::Components::FactionComponent.new(faction_id: Vanilla::Factions::MONSTER, hostile_to: [Vanilla::Factions::HERO]) }
 
   before do
     allow(Vanilla::Logger).to receive(:instance).and_return(logger)

--- a/spec/lib/vanilla/systems/message_system_combat_spec.rb
+++ b/spec/lib/vanilla/systems/message_system_combat_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe Vanilla::Systems::MessageSystem do
   let(:world) { instance_double('Vanilla::World') }
   let(:system) { described_class.new(world) }
   let(:logger) { instance_double('Vanilla::Logger') }
-  let(:player) { Vanilla::Entities::Entity.new.tap { |e| e.name = "Player"; e.add_tag(:player) } }
-  let(:monster) { Vanilla::Entities::Entity.new.tap { |e| e.name = "Goblin"; e.add_tag(:monster) } }
+  let(:player) { Vanilla::Entities::Entity.new.tap { |e| e.name = "Player"; e.add_tag(:player); e.add_component(hero_faction) } }
+  let(:monster) { Vanilla::Entities::Entity.new.tap { |e| e.name = "Goblin"; e.add_tag(:monster); e.add_component(monster_faction) } }
+  let(:hero_faction) { Vanilla::Components::FactionComponent.new(faction_id: Vanilla::Factions::HERO, hostile_to: [Vanilla::Factions::MONSTER]) }
+  let(:monster_faction) { Vanilla::Components::FactionComponent.new(faction_id: Vanilla::Factions::MONSTER, hostile_to: [Vanilla::Factions::HERO]) }
 
   before do
     allow(Vanilla::Logger).to receive(:instance).and_return(logger)


### PR DESCRIPTION
## Summary

Introduces a **faction** as the first-class notion of *who is hostile to whom*, replacing the hard-coded `has_tag?(:player) && has_tag?(:monster)` check in `AttackCommand` with a faction-based hostility query. This decouples combat targeting from "the player" and lays the groundwork for allied NPCs and monster-vs-monster combat.

This is **Phase 1 (foundation only)** — a data model + queries wired into existing combat with **no observable gameplay change**. It came out of exploring the enemy-targeting/faction discussion linked from issue #119 (`reddit_response_enemy_targeting copy.md`).

Full design: `documents/proposals/010_faction_system_proposal.md`.

## What's included

- **`FactionComponent`** — pure data (`faction_id` + `hostile_to` set). Hostility *logic* lives in `Vanilla::Factions` so the component stays within the `ECS/ComponentBehavior` cop's rules. `faction_id` defaults to `:neutral` so `Component.register` succeeds and unfactioned entities are hostile to nobody (verified via a full `Entity#to_hash`/`from_hash` round-trip).
- **`Vanilla::Factions`** — `HERO`/`MONSTER`/`NEUTRAL` constants + nil-safe `hostile?`/`allies?`.
- **`EntityFactory`** — player ⇒ `:hero` (hostile to `:monster`); monsters ⇒ `:monster` (hostile to `:hero`).
- **`AttackCommand`** — routes turn-based combat via `player_initiated_against_hostile?`. The `:player` tag is kept for the *interactive* branch (that's about control, not hostility); only "is the target an enemy?" is delegated to factions.

## Behaviour preservation

The only entities today are the player and mutually-hostile monsters, so `hostile?(player, monster)` is true exactly when the old `:monster` tag check was — combat routes identically. Entities without a faction are treated as non-hostile, matching the old non-player fallback.

## Out of scope (intentional)

`CollisionSystem` (stairs/items, not hostility), `CombatSystem` kill-credit (player *identity*, not faction), and `MonsterSystem`'s direct `player:` reference are left unchanged. Monster targeting/AI that *consumes* factions is **Phase 2** (see the proposal's Future Work).

## Testing

- New: `faction_component_spec` (init/defaults/type/registration/round-trip), `factions_spec` (hostile?/allies? incl. reciprocity, neutral, missing-component, nil), and `attack_command_spec` faction-routing cases.
- Updated: `message_system_combat*_spec` fixtures now carry factions (as real `EntityFactory` entities do).
- **`bundle exec rspec` → 562 examples, 0 failures.**

## Note

The custom `ECS/ComponentBehavior` cop raises while inspecting the `self.from_hash` of **every** component (pre-existing bug, not introduced here); it produces no offense and doesn't fail the run.