### PR TITLE
Monster AI pursuit: faction-driven hunting (Proposal 011)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,9 @@ The codebase is built around three core pillars:
    - **MazeSystem (0)**: Generates procedural mazes
    - **InputSystem (1)**: Processes keyboard input
    - **MovementSystem (2)**: Moves entities
+   - **MonsterAISystem (2.6)**: Monsters hunt visible hostiles (faction-driven pursuit, runs after FOV, before collision)
    - **CollisionSystem (3)**: Handles collisions
-   - **MonsterSystem (4)**: Monster AI and pathfinding
+   - **MonsterSystem (4)**: Monster spawning/despawning and lifecycle
    - **RenderSystem (10)**: Terminal rendering
 
 ### World Coordinator

--- a/documents/proposals/011_monster_ai_targeting_proposal.md
+++ b/documents/proposals/011_monster_ai_targeting_proposal.md
@@ -1,0 +1,157 @@
+# Monster AI Targeting (Faction-Driven Pursuit) - Proposal 011
+
+## Status
+
+**Planned (Phase 2).** Design/exploration complete; not yet implemented. Builds
+directly on the faction foundation from
+[Proposal 010](010_faction_system_proposal.md).
+
+## Overview
+
+Phase 1 gave entities factions and made combat ask *"are these two hostile?"*.
+But nothing yet *consumes* that question: monsters spawn and sit still, and the
+only way a fight starts is the player walking into a monster.
+
+Phase 2 makes monsters **hunt**. Each turn, a monster that can *see* a hostile
+target paths toward it and takes a step. When it reaches the player, the existing
+combat menu fires. Targeting is expressed in terms of `Factions.hostile?`, so the
+same code generalises to monster-vs-monster and allied NPCs later — but this
+slice deliberately ships **player-hunting only**.
+
+## Design decisions (confirmed)
+
+| Decision | Choice | Consequence |
+|---|---|---|
+| **Detection** | **FOV / line-of-sight** | Monsters must actually see the target. Requires giving monsters a `VisibilityComponent` so `FOVSystem` computes their view. Walls/corners break pursuit — more tactical, more realistic. |
+| **Contact** | **Reuse the Fight/Run menu** | When a monster steps onto the player, the existing collision → menu → combat path fires ("A goblin lunges! [1] Fight [2] Run"). Minimal new wiring; consistent with today's to-the-death duel. |
+| **First slice** | **Player-hunting only** | Monsters target the player specifically (the only hostile that exists today). The targeting query still routes through `Factions.hostile?`, so faction-generic targeting is a later, small extension. |
+
+## Background: the turn model (from code exploration)
+
+The game is strictly turn-based: **one keypress = one full system cycle**.
+Systems run in priority order, then queued commands and events are processed:
+
+```
+Input(1) → Movement(2) → FOV(2.5) → Combat(3) / Collision(3) / Loot(3)
+        → Monster(4) → Message(5) → Render(10)
+```
+
+Two facts drive the whole design:
+
+1. **`MonsterSystem` runs at priority 4 — *after* `CollisionSystem`(3).** If
+   monster movement happened there, a monster stepping onto the player would not
+   be seen by collision detection until the *next* keypress. Monster movement
+   must therefore run **before** Collision(3).
+2. **Combat is entirely player-initiated today.** Player moves →
+   `:entity_moved` → `CollisionSystem` → `:entities_collided` → `MessageSystem`
+   pops the Attack/Run menu → `AttackCommand` → `process_turn_based_combat`
+   resolves the duel to the death. There is no path for a monster to *trigger*
+   that chain; the only thing missing is that the trigger is currently reached
+   only when the *player* is the mover.
+
+## What already exists and is reused
+
+- **Pathfinding:** `Vanilla::Algorithms::Dijkstra.shortest_path(grid, start:, goal:)`
+  returns an ordered array of `Cell`s. (`lib/vanilla/algorithms/dijkstra.rb`)
+- **Movement execution:** `MovementSystem#move(entity, direction)` is public,
+  validates `cell.linked?` + tile walkability, updates the grid, and emits
+  `:entity_moved`. (`lib/vanilla/systems/movement_system.rb`)
+- **Targeting predicate:** `Vanilla::Factions.hostile?(monster, target)` (Phase 1).
+- **Visibility:** `FOVSystem` computes `visible_tiles` for *any* entity with a
+  `VisibilityComponent`; `VisibilityComponent#tile_visible?(row, col)` answers
+  line-of-sight. (`lib/vanilla/systems/fov_system.rb`)
+
+## Architecture
+
+### New system: `MonsterAISystem` (priority ~2.6)
+
+Slotted **after `FOVSystem`(2.5)** (so monster sight lines are fresh) and
+**before `CollisionSystem`(3)** (so a monster reaching the player is detected the
+same turn).
+
+Per turn, for each living monster:
+
+```ruby
+def update(_delta_time = nil)
+  target = player_target            # the player entity (Phase 2 scope)
+  return unless target
+
+  target_pos = target.get_component(:position)
+  monsters.each do |monster|
+    next unless Vanilla::Factions.hostile?(monster, target)
+    next unless can_see?(monster, target_pos)        # FOV / line-of-sight gate
+    step_toward(monster, target_pos)                 # Dijkstra + one move
+  end
+end
+```
+
+- **`can_see?`** — `monster.get_component(:visibility).tile_visible?(target.row, target.column)`.
+- **`step_toward`** — Dijkstra from the monster's cell to the target's cell, take
+  the first cell of the path, translate it to a cardinal direction, and call
+  `MovementSystem#move(monster, direction)` (looked up via `world.systems`, the
+  same pattern `AttackCommand` uses to find `CombatSystem`).
+
+Movement is executed by calling `MovementSystem#move` **directly** rather than
+setting an `InputComponent` direction, because `MovementSystem` runs at priority
+2 — *before* this system — so a direction set at 2.6 wouldn't be consumed until
+the next turn.
+
+### Entity changes (`EntityFactory.create_monster`)
+
+Monsters gain two components they currently lack:
+
+- **`MovementComponent.new(active: true)`** — required; `MovementSystem#move`
+  refuses to move an entity without an active movement component.
+- **`VisibilityComponent.new(vision_radius: …)`** — so `FOVSystem` computes the
+  monster's line of sight for the detection gate.
+
+### Combat wiring (one small change)
+
+When a monster moves onto the player, `MovementSystem` emits `:entity_moved` for
+the monster; `CollisionSystem` then emits `:entities_collided`. The only thing to
+verify/adjust is that `MessageSystem`'s collision handler raises the Fight/Run
+menu — and resolves the *monster* as the attack target — regardless of which
+entity was the mover. If it currently keys on "the player moved", it needs to
+key on "the player is one of the colliding pair" instead. No new command or
+combat path is introduced.
+
+## Risks / things to verify during implementation
+
+1. **Fog of war must stay player-only.** `RenderSystem` uses a `VisibilityComponent`
+   for fog of war. Giving monsters visibility must NOT change what the player
+   sees — confirm `RenderSystem` reads the *player's* visibility specifically,
+   not "any visibility component". **(Highest-risk item.)**
+2. **Tile bookkeeping in `MovementSystem#move`.** Confirm it updates cell tiles
+   generically (clears the old cell, marks the new one) rather than hard-coding
+   the player's tile, so a moving monster leaves the floor behind it correctly.
+3. **`MessageSystem` collision handler** — confirm mover-agnostic menu triggering
+   and correct target resolution (attack the monster, not the player).
+4. **Grid access** — confirm how a system reaches the active grid
+   (`world.current_level.grid` or similar) so `MonsterAISystem` and Dijkstra get
+   the right grid after level transitions.
+5. **Monster-on-monster blocking** — a monster whose next path cell is occupied
+   by another monster (non-walkable `MONSTER` tile) simply doesn't move that turn.
+   Acceptable for this slice; no stacking.
+6. **Performance** — FOV + Dijkstra per monster per turn. Fine at current counts
+   (≤8 monsters); note it and revisit only if profiling says so.
+
+## Testing plan
+
+- **`MonsterAISystem` unit specs:** moves one step toward a visible player; does
+  **not** move when the player is out of line of sight; does not move when no
+  hostile target exists; picks a path-correct direction; ignores non-hostile
+  entities (faction-generic readiness).
+- **`EntityFactory` specs:** monsters now carry `:movement` and `:visibility`.
+- **Integration:** a monster adjacent-with-line-of-sight closes the gap and the
+  resulting collision raises the combat menu; a monster behind a wall does not
+  pursue.
+- **Regression:** full suite stays green; fog-of-war render behaviour for the
+  player is unchanged (guards risk #1).
+
+## Out of scope (future phases)
+
+- Faction-generic targeting (monster-vs-monster, allied NPCs) — a small extension
+  of `player_target` into "nearest hostile".
+- Memory / last-known-position (continue toward where the player was last seen).
+- Aggro de-escalation, fleeing at low health, pack behaviour.
+- Removing `MonsterSystem`'s direct `@player` reference (spawn-distance logic).

--- a/lib/vanilla/entity_factory.rb
+++ b/lib/vanilla/entity_factory.rb
@@ -2,6 +2,10 @@
 
 module Vanilla
   class EntityFactory
+    # How far (in tiles) a monster can see when hunting. Line of sight is still
+    # blocked by walls, so this is an upper bound, not a guaranteed range.
+    MONSTER_VISION_RADIUS = 5
+
     def self.create_player(row, column, dev_mode: false)
       player = Vanilla::Entities::Entity.new
 
@@ -47,6 +51,11 @@ module Vanilla
       monster.add_component(Vanilla::Components::HealthComponent.new(max_health: health))
       monster.add_component(Vanilla::Components::CombatComponent.new(attack_power: damage, defense: 1, accuracy: 0.7))
       monster.add_component(Vanilla::Components::FactionComponent.new(faction_id: Vanilla::Factions::MONSTER, hostile_to: [Vanilla::Factions::HERO]))
+      # Movement lets MonsterAISystem drive the monster via MovementSystem#move;
+      # visibility lets FOVSystem compute the monster's line of sight so it only
+      # hunts targets it can actually see.
+      monster.add_component(Vanilla::Components::MovementComponent.new(active: true))
+      monster.add_component(Vanilla::Components::VisibilityComponent.new(vision_radius: MONSTER_VISION_RADIUS))
       monster
     end
   end

--- a/lib/vanilla/game.rb
+++ b/lib/vanilla/game.rb
@@ -66,6 +66,9 @@ module Vanilla
       # FOV System runs after movement (priority 2.5) - will get grid dynamically
       @fov_system = Vanilla::Systems::FOVSystem.new(@world)
       @world.add_system(@fov_system, 2.5)
+      # Monster AI runs after FOV (fresh sight lines) and before collision (so a
+      # monster reaching the player is detected on the same turn).
+      @world.add_system(Vanilla::Systems::MonsterAISystem.new(@world), 2.6)
       @world.add_system(Vanilla::Systems::CombatSystem.new(@world), 3)
       @world.add_system(Vanilla::Systems::CollisionSystem.new(@world), 3)
       @world.add_system(Vanilla::Systems::LootSystem.new(@world), 3)

--- a/lib/vanilla/support/tile_type.rb
+++ b/lib/vanilla/support/tile_type.rb
@@ -30,10 +30,11 @@ module Vanilla
       def self.walkable?(tile)
         return false unless valid?(tile)
 
-        # FIX: Treat MONSTER as walkable tile
-        # Temporary workaround: Treat MONSTER as walkable until a combat system is implemented.
-        # This ensures players can navigate mazes when the only path to stairs crosses a monster.
-        [MONSTER, EMPTY, FLOOR, DOOR, STAIRS, GOLD].include?(tile)
+        # Actors share a cell when they meet: the player steps onto a MONSTER's
+        # tile to attack it, and a hunting monster steps onto the PLAYER's tile
+        # to reach them (which triggers the combat menu via collision). Both
+        # actor tiles are therefore walkable.
+        [MONSTER, PLAYER, EMPTY, FLOOR, DOOR, STAIRS, GOLD].include?(tile)
       end
 
       # Check if the tile is a wall type (blocks movement)

--- a/lib/vanilla/systems.rb
+++ b/lib/vanilla/systems.rb
@@ -24,6 +24,7 @@ module Vanilla
     require_relative 'systems/combat_system'
     require_relative 'systems/message_system'
     require_relative 'systems/monster_system'
+    require_relative 'systems/monster_ai_system'
     require_relative 'systems/render_system'
     require_relative 'systems/render_system_factory'
     require_relative 'systems/maze_system'

--- a/lib/vanilla/systems/message_system.rb
+++ b/lib/vanilla/systems/message_system.rb
@@ -184,13 +184,20 @@ module Vanilla
           entity = @world.get_entity(data[:entity_id])
           other = @world.get_entity(data[:other_entity_id])
           @logger.debug("[MessageSystem] Entity: #{entity&.id}, tags: #{entity&.tags&.inspect}, Other: #{other&.id}, tags: #{other&.tags&.inspect}")
-          if entity&.has_tag?(:player) && other&.has_tag?(:monster)
+          player, monster = player_monster_pair(entity, other)
+          if player && monster
             @logger.info("[MessageSystem] Player-monster collision detected, adding combat message")
             # Clear options from previous combat collision messages to prevent duplicates
             clear_previous_combat_options
-            # Store collision data for attack/run away commands
-            @last_collision_data = data
-            enemy_name = other.name || "Monster"
+            # Normalise collision data so the attack/run-away callbacks always read
+            # the player as the actor and the monster as the target, regardless of
+            # which entity moved into the other.
+            @last_collision_data = {
+              entity_id: player.id,
+              other_entity_id: monster.id,
+              position: data[:position]
+            }
+            enemy_name = monster.name || "Monster"
             add_message("combat.collision",
               metadata: { enemy: enemy_name, x: data[:position][:row], y: data[:position][:column] },
               options: [
@@ -767,6 +774,18 @@ module Vanilla
             @logger.debug("[MessageSystem] Cleared options from previous combat collision message")
           end
         end
+      end
+
+      # Identify the player and monster in a colliding pair, regardless of which
+      # one moved into the other. A player walking into a monster and a monster
+      # hunting into the player both produce the same combat menu.
+      # @return [Array(Entity, Entity)] [player, monster], or [nil, nil] if the
+      #   pair isn't a player and a monster.
+      def player_monster_pair(first, second)
+        return [first, second] if first&.has_tag?(:player) && second&.has_tag?(:monster)
+        return [second, first] if second&.has_tag?(:player) && first&.has_tag?(:monster)
+
+        [nil, nil]
       end
 
       # Clear options from loot drop messages

--- a/lib/vanilla/systems/monster_ai_system.rb
+++ b/lib/vanilla/systems/monster_ai_system.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require_relative 'system'
+
+module Vanilla
+  module Systems
+    # Drives hostile monsters to hunt the player.
+    #
+    # Each turn, every monster that can SEE a hostile target (line of sight via
+    # its VisibilityComponent, refreshed by FOVSystem) takes one step toward that
+    # target along the maze's shortest path. The path is followed by descending a
+    # Dijkstra distance field rooted at the target: the monster moves to the
+    # linked neighbour with the lowest distance-to-target. When a monster steps
+    # onto the player's cell, the existing collision -> MessageSystem flow raises
+    # the Fight/Run menu (see #player_monster_pair there).
+    #
+    # Priority 2.6: after FOVSystem (2.5) so sight lines are fresh, and before
+    # CollisionSystem (3) so a monster reaching the player is detected the same
+    # turn.
+    #
+    # Scope (Phase 2, Proposal 011): monsters target the PLAYER only. Targeting
+    # is gated by Vanilla::Factions.hostile?, so extending to arbitrary hostile
+    # factions (monster infighting, allied NPCs) is a later, small change.
+    class MonsterAISystem < System
+      def update(_delta_time = nil)
+        target = @world.find_entity_by_tag(:player)
+        return unless target
+
+        grid = @world.grid
+        return unless grid
+
+        target_cell = cell_for(grid, target)
+        return unless target_cell
+
+        # Distance from the target to every reachable cell; monsters walk down it.
+        distances = target_cell.distances
+
+        monsters.each do |monster|
+          next unless Vanilla::Factions.hostile?(monster, target)
+          next unless can_see?(monster, target)
+
+          step_toward(monster, grid, distances)
+        end
+      end
+
+      private
+
+      # Living, hunt-capable monsters (have position, movement, sight and faction).
+      # @return [Array<Entity>]
+      def monsters
+        entities_with(:position, :movement, :visibility, :faction).select do |entity|
+          entity.has_tag?(:monster)
+        end
+      end
+
+      # Whether the monster currently has line of sight to the target's tile.
+      # @return [Boolean]
+      def can_see?(monster, target)
+        visibility = monster.get_component(:visibility)
+        position = target.get_component(:position)
+        visibility.tile_visible?(position.row, position.column)
+      end
+
+      # Move the monster one cell down the distance gradient toward the target.
+      def step_toward(monster, grid, distances)
+        monster_cell = cell_for(grid, monster)
+        return unless monster_cell
+
+        current_distance = distances[monster_cell]
+        return unless current_distance # target unreachable from the monster's cell
+
+        next_cell = monster_cell.links
+                                .select { |cell| distances[cell] }
+                                .min_by { |cell| distances[cell] }
+        return unless next_cell && distances[next_cell] < current_distance
+
+        direction = direction_between(monster_cell, next_cell)
+        return unless direction
+
+        movement_system&.move(monster, direction)
+      end
+
+      # Resolve the cardinal direction from a cell to one of its linked neighbours.
+      # @return [Symbol, nil]
+      def direction_between(from_cell, to_cell)
+        return :north if to_cell == from_cell.north
+        return :south if to_cell == from_cell.south
+        return :east if to_cell == from_cell.east
+        return :west if to_cell == from_cell.west
+
+        nil
+      end
+
+      # @return [Cell, nil] the grid cell an entity currently occupies
+      def cell_for(grid, entity)
+        position = entity.get_component(:position)
+        grid[position.row, position.column]
+      end
+
+      # The MovementSystem actually executes (and validates) the step, keeping
+      # all grid/tile bookkeeping in one place. Looked up the same way commands
+      # locate sibling systems.
+      def movement_system
+        @movement_system ||= @world.systems.find do |system, _priority|
+          system.is_a?(Vanilla::Systems::MovementSystem)
+        end&.first
+      end
+    end
+  end
+end

--- a/spec/lib/vanilla/support/tile_type_spec.rb
+++ b/spec/lib/vanilla/support/tile_type_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Vanilla::Support::TileType do
         described_class::FLOOR,
         described_class::DOOR,
         described_class::STAIRS,
+        described_class::PLAYER,
+        described_class::MONSTER,
       ]
 
       walkable_tiles.each do |tile|
@@ -57,8 +59,7 @@ RSpec.describe Vanilla::Support::TileType do
     it 'returns false for non-walkable tiles' do
       non_walkable_tiles = [
         described_class::WALL,
-        described_class::VERTICAL_WALL,
-        described_class::PLAYER
+        described_class::VERTICAL_WALL
       ]
 
       non_walkable_tiles.each do |tile|

--- a/spec/lib/vanilla/systems/message_system_combat_menu_spec.rb
+++ b/spec/lib/vanilla/systems/message_system_combat_menu_spec.rb
@@ -59,6 +59,28 @@ RSpec.describe Vanilla::Systems::MessageSystem do
       expect(run_away_option[:content]).to include("Run Away")
     end
 
+    it 'raises the combat menu when a monster moves into the player (reversed collision order)' do
+      # entity_id is the mover (the monster); other_entity_id is the player.
+      system.handle_event(:entities_collided, {
+        entity_id: monster.id,
+        other_entity_id: player.id,
+        position: { row: 5, column: 6 }
+      })
+
+      system.update(nil) # Process message queue
+
+      messages = system.instance_variable_get(:@manager).instance_variable_get(:@message_log).messages
+      collision_messages = messages.select { |m| m.content == "combat.collision" || (m.respond_to?(:key) && m.key == "combat.collision") }
+      expect(collision_messages).not_to be_empty
+      expect(collision_messages.first.options.size).to eq(2)
+
+      # Collision data is normalised so callbacks treat the player as the actor
+      # and the monster as the target regardless of who moved.
+      stored = system.instance_variable_get(:@last_collision_data)
+      expect(stored[:entity_id]).to eq(player.id)
+      expect(stored[:other_entity_id]).to eq(monster.id)
+    end
+
     it 'option 1 triggers attack command' do
       system.instance_variable_set(:@last_collision_data, {
         entity_id: player.id,

--- a/spec/lib/vanilla/systems/monster_ai_system_spec.rb
+++ b/spec/lib/vanilla/systems/monster_ai_system_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Vanilla::Systems::MonsterAISystem do
+  let(:world) { instance_double('Vanilla::World') }
+  let(:system) { described_class.new(world) }
+  let(:movement_system) { instance_double('Vanilla::Systems::MovementSystem') }
+
+  # A straight 1x5 corridor with every cell linked to its eastern neighbour:
+  # (0,0)-(0,1)-(0,2)-(0,3)-(0,4)
+  let(:grid) do
+    Vanilla::MapUtils::Grid.new(1, 5).tap do |g|
+      (0..3).each { |col| g[0, col].link(cell: g[0, col + 1], bidirectional: true) }
+    end
+  end
+
+  # Player sits at the east end of the corridor.
+  let(:player) do
+    Vanilla::Entities::Entity.new.tap do |e|
+      e.add_tag(:player)
+      e.add_component(Vanilla::Components::PositionComponent.new(row: 0, column: 4))
+      e.add_component(Vanilla::Components::FactionComponent.new(faction_id: Vanilla::Factions::HERO, hostile_to: [Vanilla::Factions::MONSTER]))
+    end
+  end
+
+  # Each context overrides these to position the monster and shape what it sees.
+  let(:monster_column) { 0 }
+  let(:monster_hostile) { true }
+  let(:monster_sees) { [[0, 4]] } # tiles currently visible to the monster
+  let(:monster) do
+    Vanilla::Entities::Entity.new.tap do |e|
+      e.add_tag(:monster)
+      e.add_component(Vanilla::Components::PositionComponent.new(row: 0, column: monster_column))
+      e.add_component(Vanilla::Components::MovementComponent.new(active: true))
+      hostile_to = monster_hostile ? [Vanilla::Factions::HERO] : []
+      e.add_component(Vanilla::Components::FactionComponent.new(faction_id: Vanilla::Factions::MONSTER, hostile_to: hostile_to))
+      visibility = Vanilla::Components::VisibilityComponent.new(vision_radius: 5)
+      monster_sees.each { |(row, col)| visibility.add_visible_tile(row, col) }
+      e.add_component(visibility)
+    end
+  end
+
+  let(:player_present) { true }
+
+  before do
+    allow(world).to receive(:find_entity_by_tag).with(:player).and_return(player_present ? player : nil)
+    allow(world).to receive_messages(grid: grid, query_entities: [monster], systems: [[movement_system, 2]])
+    allow(movement_system).to receive(:is_a?).with(Vanilla::Systems::MovementSystem).and_return(true)
+    allow(movement_system).to receive(:move)
+  end
+
+  describe '#update' do
+    context 'when a hostile player is visible' do
+      it 'steps one cell toward the player' do
+        system.update(nil)
+        # From (0,0) the only lower-distance neighbour is (0,1), which lies east.
+        expect(movement_system).to have_received(:move).with(monster, :east)
+      end
+    end
+
+    context 'when the monster is adjacent to the player' do
+      let(:monster_column) { 3 }
+
+      it 'steps onto the player\'s cell (which triggers the combat collision)' do
+        system.update(nil)
+        expect(movement_system).to have_received(:move).with(monster, :east)
+      end
+    end
+
+    context 'when the monster cannot see the player' do
+      let(:monster_sees) { [] }
+
+      it 'does not move' do
+        system.update(nil)
+        expect(movement_system).not_to have_received(:move)
+      end
+    end
+
+    context 'when the target is not hostile to the monster' do
+      let(:monster_hostile) { false }
+
+      it 'does not move' do
+        system.update(nil)
+        expect(movement_system).not_to have_received(:move)
+      end
+    end
+
+    context 'when there is no player' do
+      let(:player_present) { false }
+
+      it 'does nothing' do
+        system.update(nil)
+        expect(movement_system).not_to have_received(:move)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 2 of the faction work ([Proposal 010](../blob/main/documents/proposals/010_faction_system_proposal.md) shipped the data model; this makes something *consume* it). **Monsters now hunt the player** instead of sitting still.

Each turn, a monster that can **see** a hostile target (FOV line of sight) steps one cell toward it along the maze's shortest path. When it reaches the player, the **existing Fight/Run menu** fires. Design doc: `documents/proposals/011_monster_ai_targeting_proposal.md`.

Confirmed design choices: **FOV/line-of-sight detection**, **reuse the Fight/Run menu** on contact, **player-hunting only** for this slice.

## What's included

- **`MonsterAISystem` (priority 2.6)** — after `FOVSystem`(2.5) so sight lines are fresh, before `CollisionSystem`(3) so reaching the player is detected the same turn. For each monster: gate on `Factions.hostile?` + line of sight, then descend a **player-rooted Dijkstra distance field** (the robust approach — the monster moves to the linked neighbour with the lowest distance-to-player), executing the step via the existing `MovementSystem#move`.
- **`EntityFactory`** — monsters gain `MovementComponent` (so they can move) and `VisibilityComponent` (so `FOVSystem` computes their sight).
- **`TileType.walkable?`** — `PLAYER` is now walkable, so a monster steps onto the player's cell exactly as the player already steps onto a monster's. `walkable?` is used only by movement validation, and the parallel `CellType` abstraction already treated the player as walkable.
- **`MessageSystem`** — the `entities_collided` handler now identifies the player/monster pair regardless of which entity moved and normalises `@last_collision_data`, so monster-initiated contact raises the same menu with correct target resolution.

## Reuse (no new machinery)

Dijkstra pathfinding (`Dijkstra`/`Cell#distances`), `MovementSystem#move`, `FOVSystem`, and the Phase-1 `Factions.hostile?` predicate all already existed.

## Risk that was checked first

**Fog of war stays player-only.** `RenderSystem` fetches `find_entity_by_tag(:player)` and reads *that* visibility (`render_system.rb:44`), so giving monsters their own `VisibilityComponent` does not change what the player sees. Verified before building.

## Testing

- **New:** `monster_ai_system_spec` — steps toward a visible hostile, steps onto the player when adjacent, and stays put when blind / non-hostile / no player.
- **Updated:** `tile_type_spec` (PLAYER/MONSTER walkable); `message_system_combat_menu_spec` (menu fires on reversed/monster-initiated collision with normalised data).
- **Integration (real objects, no mocks):** wired `FOVSystem` → `MonsterAISystem` → real `MovementSystem` on a linked grid; the monster walks one cell closer to the player each tick.
- **`bundle exec rspec` → 568 examples, 0 failures.**

## Out of scope (future)

Faction-generic targeting (monster-vs-monster, allied NPCs — a small extension of `player_target` to "nearest hostile"), last-known-position memory, fleeing/pack behaviour, and removing `MonsterSystem`'s direct `@player` spawn reference.